### PR TITLE
Changed AudioStream player node order

### DIFF
--- a/scenes/menus/start.tscn
+++ b/scenes/menus/start.tscn
@@ -109,7 +109,7 @@ text = "Queue Gobblin"
 
 [node name="AudioListener2D" type="AudioListener2D" parent="."]
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="AudioListener2D"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("7_0sim4")
 volume_db = 15.0
 autoplay = true


### PR DESCRIPTION
Accidently made AudioStream a child node of Audio listener. Made them separate