### PR TITLE
Fixed drop off zone duplication

### DIFF
--- a/scenes/menus/start.tscn
+++ b/scenes/menus/start.tscn
@@ -108,8 +108,8 @@ theme_override_font_sizes/font_size = 60
 text = "Queue Gobblin"
 
 [node name="AudioListener2D" type="AudioListener2D" parent="."]
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("7_0sim4")
 volume_db = 15.0
 autoplay = true

--- a/scripts/inventory/dropoff/dropoff_zone.gd
+++ b/scripts/inventory/dropoff/dropoff_zone.gd
@@ -39,8 +39,10 @@ func _on_body_exited(body: Node2D) -> void:
 		foodDialog.hide()
 		
 func _update_pass_inventory(clear : bool):
+	items = []
+	
 	var player_inventory = get_tree().get_first_node_in_group("inventory").inventory
-		
+	
 	for n in player_inventory.items.size():
 		var item = player_inventory.items[n]
 		

--- a/scripts/inventory/sandwich_building/sandwich_scene.gd
+++ b/scripts/inventory/sandwich_building/sandwich_scene.gd
@@ -6,7 +6,7 @@ signal points_gained(num, item)
 
 @onready var scorelabel = $StaticBody2D/PanelContainer/VBoxContainer/Panel/VBoxContainer/ScoreLabel
 var score := 0
-var score_threshhold := 160
+var score_threshhold := 120
 var rolling := false
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:


### PR DESCRIPTION
- Fixed issue where items would duplicate in sandwich scene due to items being added to the array incorrectly in the drop off zone.

- Fixed issue where threshold was set higher than the value displayed on the screen.